### PR TITLE
Add clear password authentication

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -14,12 +14,17 @@ my $prefs = preferences('plugin.squeezesonic');
 my $log = logger('plugin.squeezesonic');
 
 sub getAuth {
+	my $auth;
 	my $user = $prefs->get('username');
 	my $pass = $prefs->get('password');
+	if ( $prefs->get('auth') eq "password" ) {
+		$auth = "u=$user&p=$pass&v=1.11.0&f=json&c=SqueezeSonic";
+		return $auth;
+	}
 	my @chars = ('A'..'Z', 'a'..'z', 0..9);
 	my $salt = join '', map $chars[rand @chars], 0..8;
         my $token = md5_hex($pass . $salt);
-	my $auth = "u=$user&t=$token&s=$salt&v=1.11.0&f=json&c=SqueezeSonic";
+	$auth = "u=$user&t=$token&s=$salt&v=1.11.0&f=json&c=SqueezeSonic";
 	return $auth;
 }
 

--- a/HTML/EN/plugins/SqueezeSonic/settings/basic.html
+++ b/HTML/EN/plugins/SqueezeSonic/settings/basic.html
@@ -24,5 +24,11 @@
                         	<option [% prefs.asize == "150" ? "selected" : "" %] value="150" >150</option>
                         </select>
 		[% END %]
+		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_AUTH_TYPE" desc="Preferred auth type, token hides the password but it is not implemented by all subsonic servers." %]
+			<select name="auth" id="auth">
+                        	<option [% prefs.auth == "token" ? "selected" : "" %] value="token" >token</option>
+                        	<option [% prefs.auth == "password" ? "selected" : "" %] value="password" >password</option>
+                        </select>
+		[% END %]
 	[% END %]
 [% PROCESS settings/footer.html %]

--- a/Settings.pm
+++ b/Settings.pm
@@ -30,22 +30,22 @@ sub prefs {
 
 sub handler {
 	my ($class, $client, $params) = @_;
-	
+
 	if ($params->{'saveSettings'} && $params->{'username'} && $params->{'suburl'}) {
 		if ($params->{'username'}) {
 			$prefs->set('username', $params->{'username'});
 		}
-	
+
 		if ($params->{'password'} && ($params->{'password'} ne "**********")) {
 			$prefs->set('password', $params->{'password'});
 		}
-		
+
 		if ($params->{'suburl'}) {
 			if ($params->{'suburl'} =~ m/^https?/) {
 				$prefs->set('suburl', $params->{'suburl'});
 			} else {
 				$prefs->set('suburl', "http://" . $params->{'suburl'});
-			}			
+			}
 		}
 		if ($params->{'slists'}) {
 			$prefs->set('slists', $params->{'slists'});
@@ -62,7 +62,10 @@ sub handler {
 		if ($params->{'asize'}) {
 			$prefs->set('asize', $params->{'asize'});
 		}
-	}	
+ 		if ($params->{'auth'}) {
+			$prefs->set('auth', $params->{'auth'});
+		}
+	}
 
 	$params->{'prefs'}->{'username'} = $prefs->get('username');
 	$params->{'prefs'}->{'password'} = "**********";
@@ -72,6 +75,7 @@ sub handler {
 	$params->{'prefs'}->{'tmusic'} = $prefs->get('tmusic') || '3600';
 	$params->{'prefs'}->{'transcode'} = $prefs->get('transcode') || 'raw';
 	$params->{'prefs'}->{'asize'} = $prefs->get('asize') || '800';
+	$params->{'prefs'}->{'auth'} = $prefs->get('auth') || 'token';
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/strings.txt
+++ b/strings.txt
@@ -7,15 +7,15 @@ PLUGIN_SQUEEZESONIC
 PLUGIN_SQUEEZESONIC_DESC
 	EN	Listen music from a Subsonic API capable (>1.11.0) backend - "Fabino's edition"
 	FR	Se connecte à un serveur proposant l'API Subsonic (>1.11.0) - "Fabino's edition"
-	
+
 PLUGIN_SQUEEZESONIC_REQUIRES_CREDENTIALS
 	EN	Please enter your connection information in Server Settings/Advanced/SqueezeSonic
 	FR	Renseignez vos informations de connexion dans Paramètres/Avancé/SqueezeSonic
-	
+
 PLUGIN_SQUEEZESONIC_PREFS_USER
 	EN	Username
 	FR	Utilisateur
-	
+
 PLUGIN_SQUEEZESONIC_PREFS_PASSWORD
 	EN	Password
 	FR	Mot de passe
@@ -43,7 +43,7 @@ PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE
 PLUGIN_SQUEEZESONIC_PREFS_ARTWORK_SIZE
 	EN	Artwork prefered size in pixels
 	FR	Taille des couvertures d'album & images en pixels
-	
+
 PLUGIN_SQUEEZESONIC_RANDOM
 	EN	Random albums
 	FR	Albums Aleatoires
@@ -81,8 +81,8 @@ PLUGIN_SQUEEZESONIC_STARTRADIO
 	FR	Radio
 
 PLUGIN_SQUEEZESONIC_MINIMUM_VERSION
-	EN	Sorry, minimum supported API version is 1.11.0 (Subsonic 5.1). Your current version is 
-	FR	Désolé, la version minimale supportée de l'API est 1.11.0 (Subsonic 5.1). Votre version est 
+	EN	Sorry, minimum supported API version is 1.11.0 (Subsonic 5.1). Your current version is
+	FR	Désolé, la version minimale supportée de l'API est 1.11.0 (Subsonic 5.1). Votre version est
 
 PLUGIN_SQUEEZESONIC_SOMETHING_WRONG
 	EN	Something went wrong. Please verify your connection information in Server Settings/Advanced/SqueezeSonic
@@ -99,3 +99,7 @@ PLUGIN_SQUEEZESONIC_PODCASTS
 PLUGIN_SQUEEZESONIC_REFRESH
 	EN	Refresh lists
 	FR	Rafraichir les listes
+
+PLUGIN_SQUEEZESONIC_PREFS_AUTH_TYPE
+	EN	Authentication Type
+	FR	Type d'authentification


### PR DESCRIPTION
closes #4 

For subsonic servers that don't handle token (like Nextcloud).
Default is still to use token instead of clear password.