### PR TITLE
Split transcode settings into transcodeFormat and transcodeBitrate

### DIFF
--- a/HTML/EN/plugins/SqueezeSonic/settings/basic.html
+++ b/HTML/EN/plugins/SqueezeSonic/settings/basic.html
@@ -6,14 +6,23 @@
 		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_LISTS_SIZE" desc="Number of elements present in lists and returned by searches" %]<input type="text" class="stdedit" name="slists" id="slists" value="[% prefs.slists %]" size="5" />[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_TIMEOUT_LISTS" desc="Timeout of genrated list in seconds" %]<input type="text" class="stdedit" name="tlists" id="tlists" value="[% prefs.tlists %]" size="5" />[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_TIMEOUT_MUSIC" desc="Timeout for cached albums & songs in seconds" %]<input type="text" class="stdedit" name="tmusic" id="tmusic" value="[% prefs.tmusic %]" size="5" />[% END %]
-		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE" desc="Some delay may be needed after changing format to replay previously played songs" %]
-			<select name="transcode" id="transcode">
-                        	<option [% prefs.transcode == "raw" ? "selected" : "" %] value="raw" >Disabled (raw)</option>
-                        	<option [% prefs.transcode == "320" ? "selected" : "" %] value="320" >MP3 320 kbps</option>
-                        	<option [% prefs.transcode == "256" ? "selected" : "" %] value="256" >MP3 256 kbps</option>
-                        	<option [% prefs.transcode == "128" ? "selected" : "" %] value="128" >MP3 128 kbps</option>
-                        	<option [% prefs.transcode == "64" ? "selected" : "" %] value="64" >MP3 64 kbps</option>
-                        </select>
+		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE_BITRATE" desc="Some delay may be needed after changing bitrate to replay previously played songs" %]
+				<select name="transcodeBitrate" id="transcodeBitrate">
+						<option [% prefs.transcodeBitrate == "raw" ? "selected" : "" %] value="raw" >Disabled (raw)</option>
+						<option [% prefs.transcodeBitrate == "320" ? "selected" : "" %] value="320" >320 kbps</option>
+						<option [% prefs.transcodeBitrate == "256" ? "selected" : "" %] value="256" >256 kbps</option>
+						<option [% prefs.transcodeBitrate == "128" ? "selected" : "" %] value="128" >128 kbps</option>
+						<option [% prefs.transcodeBitrate == "64" ? "selected" : "" %] value="64" >64 kbps</option>
+				</select>
+		[% END %]
+		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE_FORMAT" desc="Not all subsonic servers allow Automatic transcoding format definition. Some delay may be needed after changing format to replay previously played songs" %]
+				<select name="transcodeFormat" id="transcodeFormat">
+						<option [% prefs.transcodeFormat == "raw" ? "selected" : "" %] value="raw" >Disabled (raw)</option>
+						<option [% prefs.transcodeFormat == "auto" ? "selected" : "" %] value="auto" >Auto</option>
+						<option [% prefs.transcodeFormat == "mp3" ? "selected" : "" %] value="mp3" >MP3</option>
+						<option [% prefs.transcodeFormat == "ogg" ? "selected" : "" %] value="ogg" >OGG</option>
+						<option [% prefs.transcodeFormat == "flac" ? "selected" : "" %] value="flac" >FLAC</option>
+				</select>
 		[% END %]
 		[% WRAPPER settingGroup title="PLUGIN_SQUEEZESONIC_PREFS_ARTWORK_SIZE" desc="Artwork prefered size in pixels" %]
 			<select name="asize" id="asize">

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -427,26 +427,33 @@ sub _formatTrack {
 
 sub _cacheTrack {
 	my ($track) = @_;
-	                
-        $track->{image} = _getImage($track->{coverArt});
-	
-	my $tid;
-	if ($prefs->get('transcode') ne 'raw' && $track->{transcodedSuffix}) {
-			$tid = $track->{id} . "-" . $prefs->get('transcode') . "." . $track->{transcodedSuffix};
-			$track->{bitrate} = $prefs->get('transcode');
 
-        }else{
-                        my $format = $track->{suffix};
-                        if ($format =~ /^flac$/) {
-                                $format =~ s/flac/flc/;
-                        }
-			$tid = $track->{id} . "-" . "raw" . "." . $format;
-        }
+	$track->{image} = _getImage($track->{coverArt});
+
+	my $format = $track->{suffix};
+	if ($prefs->get('transcodeFormat') eq 'auto') {
+		if ($track->{transcodedSuffix}) {
+			$format = $track->{transcodedSuffix};
+		} else {
+			$log->is_error && $log->error( 'PLUGIN_SQUEEZESONIC_TRANSCODE_AUTO_NOT_DETERMINED' );
+		}
+	} elsif ($prefs->get('transcodeFormat') ne 'raw') {
+		$format = $prefs->get('transcodeFormat');
+	}
+	if ($format =~ /^flac$/) {
+		$format =~ s/flac/flc/;
+	}
+	my $bitrate = "raw";
+	if ($prefs->get('transcodeBitrate') ne 'raw') {
+		$bitrate = "$prefs->get('transcodeBitrate')";
+		$track->{bitrate} = $prefs->get('transcode');
+	}
+	my $tid = $track->{id} . "-" . $bitrate . "." . $format;
 
 	if ($prefs->get('suburl') =~ m/^https/){
-	        $track->{play}='sonics://' . $tid;
+		$track->{play}='sonics://' . $tid;
 	} else {
-	        $track->{play}='sonic://' . $tid;
+		$track->{play}='sonic://' . $tid;
 	}
 	Plugins::SqueezeSonic::API->cacheSet("getSong" . $tid,$track,$prefs->get('tmusic'));
 	return $track;

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -109,19 +109,24 @@ sub getNextTrack {
 
 		my $auth=Plugins::SqueezeSonic::API->getAuth();
 
-		my ($format) = my ($format) = $url =~ m{\.(.+?)$};
+		my ($format) = $url =~ m{\.(.+?)$};
 		my ($bitrate) = ($url =~ m{-(.*)\.});
 
 		$tid = $track->{streamId} if $track->{type} eq 'podcast';
-		
-		if ($bitrate eq "raw") {
-			$stream = $prefs->get('suburl') . "/rest/stream?id=" . $tid . "&format=raw&" . $auth;
-			$br = $track->{bitRate}*1000;
-                } else {
-			$stream = $prefs->get('suburl') . "/rest/stream?id=" . $tid . "&format=" . $format . "&estimateContentLength=true&maxBitRate=" . $bitrate . "&" . $auth;			
-			$br = $bitrate*1000;
+
+		if ($format eq $track->{suffix}) {
+			$format = "raw";
 		}
-                $song->pluginData($format);
+		my $transcode = "format=" . $format;
+		if ($bitrate ne "raw") {
+			$transcode = $transcode . "&estimateContentLength=true&maxBitRate=" . $bitrate;
+			$br = $bitrate*1000;
+		} else {
+			$br = $track->{bitRate}*1000;
+		}
+		$stream = $prefs->get('suburl') . "/rest/stream?id=" . $tid . "&" . $transcode . "&" . $auth;
+
+		$song->pluginData($format);
 		$song->streamUrl($stream);
 		$song->duration($track->{duration});
 		$song->bitrate($br);

--- a/Settings.pm
+++ b/Settings.pm
@@ -56,8 +56,11 @@ sub handler {
 		if ($params->{'tmusic'}) {
 			$prefs->set('tmusic', $params->{'tmusic'});
 		}
-		if ($params->{'transcode'}) {
-			$prefs->set('transcode', $params->{'transcode'});
+		if ($params->{'transcodeBitrate'}) {
+			$prefs->set('transcodeBitrate', $params->{'transcodeBitrate'});
+		}
+		if ($params->{'transcodeFormat'}) {
+			$prefs->set('transcodeFormat', $params->{'transcodeFormat'});
 		}
 		if ($params->{'asize'}) {
 			$prefs->set('asize', $params->{'asize'});
@@ -70,7 +73,8 @@ sub handler {
 	$params->{'prefs'}->{'slists'} = $prefs->get('slists') || '200';
 	$params->{'prefs'}->{'tlists'} = $prefs->get('tlists') || '600';
 	$params->{'prefs'}->{'tmusic'} = $prefs->get('tmusic') || '3600';
-	$params->{'prefs'}->{'transcode'} = $prefs->get('transcode') || 'raw';
+	$params->{'prefs'}->{'transcodeBitrate'} = $prefs->get('transcodeBitrate') || 'raw';
+	$params->{'prefs'}->{'transcodeFormat'} = $prefs->get('transcodeFormat') || 'raw';
 	$params->{'prefs'}->{'asize'} = $prefs->get('asize') || '800';
 
 	return $class->SUPER::handler($client, $params);

--- a/strings.txt
+++ b/strings.txt
@@ -36,9 +36,13 @@ PLUGIN_SQUEEZESONIC_PREFS_TIMEOUT_MUSIC
 	EN	Timeout for cached albums & songs in seconds
 	FR	Timeout du cache pour les albums et morceaux
 
-PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE
-	EN	Transcode format and quality
-	FR	Format et qualité du transcodage
+PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE_BITRATE
+	EN	Transcode max bitrate
+	FR	Bitrate maximum du transcodage
+
+PLUGIN_SQUEEZESONIC_PREFS_TRANSCODE_FORMAT
+	EN	Transcode format
+	FR	Format du transcodage
 
 PLUGIN_SQUEEZESONIC_PREFS_ARTWORK_SIZE
 	EN	Artwork prefered size in pixels
@@ -99,3 +103,7 @@ PLUGIN_SQUEEZESONIC_PODCASTS
 PLUGIN_SQUEEZESONIC_REFRESH
 	EN	Refresh lists
 	FR	Rafraichir les listes
+
+PLUGIN_SQUEEZESONIC_TRANSCODE_AUTO_NOT_DETERMINED
+	EN	Cannot determine Auto transcoding format because Subsonic server does not send transcodedSuffix. Fallback to raw format.
+	FR	Impossible de déterminer le format de transcodage Auto car le serveur Subsonic n'envoie pas transcodedSuffix. Pas de transcodage utilisé.


### PR DESCRIPTION
Not all subsonic servers implement the `transcodedSuffix` response key. Therefore transcoding is not working with such servers.
This PR adds an option to choose the filetype to use for transcoding (`mp3`, `ogg`, or `flac`). Choosing `raw` means no transcoding. And `auto` is the previous behavior, using the `transcodedSuffix` response (if present, otherwise no transcoding is done).